### PR TITLE
add delivery timeout to config

### DIFF
--- a/eventstream.go
+++ b/eventstream.go
@@ -134,6 +134,7 @@ type PublishBuilder struct {
 	payload          map[string]interface{}
 	errorCallback    func(event *Event, err error)
 	ctx              context.Context
+	deliveryTimeout  time.Duration
 }
 
 // NewPublish create new PublishBuilder instance
@@ -281,6 +282,13 @@ func (p *PublishBuilder) ErrorCallback(errorCallback func(event *Event, err erro
 // default: context.Background()
 func (p *PublishBuilder) Context(ctx context.Context) *PublishBuilder {
 	p.ctx = ctx
+	return p
+}
+
+// Delivery timeout is an upper bound on the time to report success or failure after a call to send() returns.
+// The value of this config should be greater than or equal to the sum of request.timeout.ms and linger.ms.
+func (p *PublishBuilder) DeliveryTimeout(timeout time.Duration) *PublishBuilder {
+	p.deliveryTimeout = timeout
 	return p
 }
 

--- a/example/main.go
+++ b/example/main.go
@@ -25,6 +25,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+type Payload struct {
+	FriendID string `json:"friendId"`
+}
+
 // nolint: funlen
 func main() {
 
@@ -40,6 +44,63 @@ func main() {
 	prefix := "example"
 
 	client, err := eventstream.NewClient(prefix, "kafka", []string{"localhost:9092"}, config)
+	if err != nil {
+		logrus.Error(err)
+	}
+
+	var mockPayload = make(map[string]interface{})
+	mockPayload["testPayload"] = Payload{FriendID: "user456"}
+
+	mockAdditionalFields := map[string]interface{}{
+		"summary": "user:_failed",
+	}
+
+	mockEvent := &eventstream.Event{
+		EventName:        "testEvent",
+		Namespace:        "event",
+		ClientID:         "fe5bd0e3dc184d2d8ae0e09fcedf0f51",
+		TraceID:          "882da8cddd174d12af25da6310b47bd5",
+		SpanContext:      "test-span-context",
+		UserID:           "48bf8a020b584f31bc605bf65d3300ed",
+		SessionID:        "c1ab4f754acc4cb48a8f68dd25cfca21",
+		EventID:          3,
+		EventType:        301,
+		EventLevel:       3,
+		ServiceName:      "test",
+		ClientIDs:        []string{"7d480ce0e8624b02901bd80d9ba9817c"},
+		TargetUserIDs:    []string{"1fe7f425a0e049d29d87ca3d32e45b5a"},
+		TargetNamespace:  "publisher",
+		Privacy:          true,
+		AdditionalFields: mockAdditionalFields,
+		Version:          2,
+		Payload:          mockPayload,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+	defer cancel()
+
+	err = client.Publish(eventstream.NewPublish().
+		Topic("topic").
+		EventName(mockEvent.EventName).
+		Namespace(mockEvent.Namespace).
+		ClientID(mockEvent.ClientID).
+		UserID(mockEvent.UserID).
+		SessionID(mockEvent.SessionID).
+		TraceID(mockEvent.TraceID).
+		SpanContext(mockEvent.SpanContext).
+		EventID(mockEvent.EventID).
+		EventType(mockEvent.EventType).
+		EventLevel(mockEvent.EventLevel).
+		ServiceName(mockEvent.ServiceName).
+		ClientIDs(mockEvent.ClientIDs).
+		TargetUserIDs(mockEvent.TargetUserIDs).
+		TargetNamespace(mockEvent.TargetNamespace).
+		Privacy(mockEvent.Privacy).
+		AdditionalFields(mockEvent.AdditionalFields).
+		Version(2).
+		Context(ctx).
+		Payload(mockPayload).
+		DeliveryTimeout(time.Second * 2))
 	if err != nil {
 		logrus.Error(err)
 	}

--- a/example/main.go
+++ b/example/main.go
@@ -76,9 +76,6 @@ func main() {
 		Payload:          mockPayload,
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
-	defer cancel()
-
 	err = client.Publish(eventstream.NewPublish().
 		Topic("topic").
 		EventName(mockEvent.EventName).
@@ -98,9 +95,9 @@ func main() {
 		Privacy(mockEvent.Privacy).
 		AdditionalFields(mockEvent.AdditionalFields).
 		Version(2).
-		Context(ctx).
+		Context(context.Background()).
 		Payload(mockPayload).
-		DeliveryTimeout(time.Second * 2))
+		DeliveryTimeout(time.Millisecond * 1))
 	if err != nil {
 		logrus.Error(err)
 	}

--- a/kafka.go
+++ b/kafka.go
@@ -155,6 +155,10 @@ func (client *KafkaClient) Publish(publishBuilder *PublishBuilder) error {
 		return fmt.Errorf("unable to construct event : %s , error : %v", publishBuilder.eventName, err)
 	}
 
+	if publishBuilder.deliveryTimeout != 0 {
+		client.configMap.SetKey("delivery.timeout.ms", publishBuilder.deliveryTimeout)
+	}
+
 	config := client.configMap
 
 	if len(publishBuilder.topic) > 1 {
@@ -222,6 +226,10 @@ func (client *KafkaClient) PublishSync(publishBuilder *PublishBuilder) error {
 			WithField("Event Name", publishBuilder.eventName).
 			Error("unable to construct event: ", err)
 		return fmt.Errorf("unable to construct event : %s , error : %v", publishBuilder.eventName, err)
+	}
+
+	if publishBuilder.deliveryTimeout != 0 {
+		client.configMap.SetKey("delivery.timeout.ms", publishBuilder.deliveryTimeout)
 	}
 
 	config := client.configMap

--- a/kafka.go
+++ b/kafka.go
@@ -158,13 +158,7 @@ func (client *KafkaClient) Publish(publishBuilder *PublishBuilder) error {
 	config := client.configMap
 
 	if publishBuilder.deliveryTimeout != 0 {
-		err := func() error {
-			client.configMapLock.Lock()
-			defer client.configMapLock.Unlock()
-
-			err = config.SetKey("delivery.timeout.ms", publishBuilder.deliveryTimeout)
-			return err
-		}()
+		err = config.SetKey("delivery.timeout.ms", publishBuilder.deliveryTimeout)
 		if err != nil {
 			return err
 		}
@@ -240,13 +234,7 @@ func (client *KafkaClient) PublishSync(publishBuilder *PublishBuilder) error {
 	config := client.configMap
 
 	if publishBuilder.deliveryTimeout != 0 {
-		err := func() error {
-			client.configMapLock.Lock()
-			defer client.configMapLock.Unlock()
-
-			err = config.SetKey("delivery.timeout.ms", publishBuilder.deliveryTimeout)
-			return err
-		}()
+		err = config.SetKey("delivery.timeout.ms", publishBuilder.deliveryTimeout)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Tested config sent to confluent lib:
![Screenshot from 2023-11-22 14-12-53](https://github.com/thoriqsatriya/eventstream-go-sdk/assets/16968748/464652c3-8fd5-4e06-a865-d1baff3c79ad)
