### PR TITLE
add: options to commit async or sync message

### DIFF
--- a/eventstream.go
+++ b/eventstream.go
@@ -311,6 +311,8 @@ type SubscribeBuilder struct {
 	callbackRaw func(ctx context.Context, msgValue []byte, err error) error
 	// flag to send error message to DLQ
 	sendErrorDLQ bool
+	// flag to use async commit consumer
+	asyncCommitMessage bool
 }
 
 // NewSubscribe create new SubscribeBuilder instance
@@ -372,6 +374,12 @@ func (s *SubscribeBuilder) Context(ctx context.Context) *SubscribeBuilder {
 // DLQ topic: 'topic' + -dlq
 func (s *SubscribeBuilder) SendErrorDLQ(dlq bool) *SubscribeBuilder {
 	s.sendErrorDLQ = dlq
+	return s
+}
+
+// AsyncCommitMessage to asynchronously commit message offset.
+func (s *SubscribeBuilder) AsyncCommitMessage(async bool) *SubscribeBuilder {
+	s.asyncCommitMessage = async
 	return s
 }
 

--- a/example/main.go
+++ b/example/main.go
@@ -116,7 +116,8 @@ func main() {
 
 				return nil
 			}).
-			SendErrorDLQ(true))
+			SendErrorDLQ(true).
+			AsyncCommitMessage(true))
 
 	if err != nil {
 		logrus.Error(err)


### PR DESCRIPTION
Test:
commit works in async options, return offset
![Screenshot from 2023-11-29 09-10-46](https://github.com/thoriqsatriya/eventstream-go-sdk/assets/16968748/ef3df00b-242a-4c28-86ad-ca81336f548a)
